### PR TITLE
alter masquerade before sending back to queue

### DIFF
--- a/direct.go
+++ b/direct.go
@@ -224,9 +224,9 @@ func (d *direct) dialWith(in chan *Masquerade, network string) (net.Conn, bool, 
 			if err := d.headCheck(m); err != nil {
 				log.Tracef("Could not perform successful head request: %v", err)
 			} else {
+				m.LastVetted = time.Now()
 				// Requeue the working connection to masquerades
 				d.masquerades <- m
-				m.LastVetted = time.Now()
 				select {
 				case d.toCache <- m:
 					// ok


### PR DESCRIPTION
Saw it by chance at https://app.wercker.com/getlantern/flashlight/runs/build/5922cef4d5bbed00013439c2?step=5922cf0bb9c68900014cc84c

This should be able to fix it.  I tried to add test case in `fronted` but couldn't reproduce reliably. @oxtoacart could you have a look?