### PR TITLE
Only retrying idempotent HTTP methods

### DIFF
--- a/direct.go
+++ b/direct.go
@@ -225,7 +225,14 @@ func (d *direct) RoundTrip(req *http.Request) (*http.Response, error) {
 			return nil, fmt.Errorf("Unable to read request body: %v", err)
 		}
 	}
-	for i := 0; i < maxTries; i++ {
+
+	isIdempotent := req.Method != http.MethodPost && req.Method != http.MethodPatch
+	tries := 1
+	if isIdempotent {
+		tries = maxTries
+	}
+
+	for i := 0; i < tries; i++ {
 		if body != nil {
 			req.Body = ioutil.NopCloser(bytes.NewReader(body))
 		}


### PR DESCRIPTION
It occurs to me that not just for the new enhttp stuff, but also direct domain-fronting, we don't want to take the chance of double-posting non-idempotent requests (imagine for example a call to the pro server that updates state). This PR takes care of that.