### PR TITLE
Per provider host alias config

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -36,6 +36,10 @@ func (d *direct) prepopulateMasquerades(cacheFile string) []masquerade {
 		now := time.Now()
 		for _, m := range masquerades {
 			if now.Sub(m.LastVetted) < d.maxAllowedCachedAge {
+				// fill in default for masquerades lacking provider id
+				if m.ProviderID == "" {
+					m.ProviderID = d.defaultProviderID
+				}
 				select {
 				case d.masquerades <- m:
 					// submitted

--- a/cache.go
+++ b/cache.go
@@ -40,6 +40,12 @@ func (d *direct) prepopulateMasquerades(cacheFile string) []masquerade {
 				if m.ProviderID == "" {
 					m.ProviderID = d.defaultProviderID
 				}
+				// Skip entries for providers that are not configured.
+				_, ok := d.providers[m.ProviderID]
+				if !ok {
+					log.Debugf("Skipping cached entry for unknown/disabled provider %s", m.ProviderID)
+					continue
+				}
 				select {
 				case d.masquerades <- m:
 					// submitted

--- a/cache_test.go
+++ b/cache_test.go
@@ -32,9 +32,9 @@ func TestCaching(t *testing.T) {
 	}
 
 	now := time.Now()
-	ma := masquerade{Masquerade{Domain: "a", IpAddress: "1"}, now}
-	mb := masquerade{Masquerade{Domain: "b", IpAddress: "2"}, now}
-	mc := masquerade{Masquerade{Domain: "c", IpAddress: "3"}, now}
+	ma := masquerade{Masquerade{Domain: "a", IpAddress: "1"}, now, testProviderID}
+	mb := masquerade{Masquerade{Domain: "b", IpAddress: "2"}, now, testProviderID}
+	mc := masquerade{Masquerade{Domain: "c", IpAddress: "3"}, now, testProviderID}
 
 	d := makeDirect()
 	d.toCache <- ma

--- a/cache_test.go
+++ b/cache_test.go
@@ -23,9 +23,11 @@ func TestCaching(t *testing.T) {
 			candidates:          make(chan masquerade, 1000),
 			masquerades:         make(chan masquerade, 1000),
 			maxAllowedCachedAge: 250 * time.Millisecond,
-			maxCacheSize:        2,
+			maxCacheSize:        3,
 			cacheSaveInterval:   50 * time.Millisecond,
 			toCache:             make(chan masquerade, 1000),
+			providers:           testProviders(),
+			defaultProviderID:   testProviderID,
 		}
 		go d.fillCache(make([]masquerade, 0), cacheFile)
 		return d
@@ -34,12 +36,14 @@ func TestCaching(t *testing.T) {
 	now := time.Now()
 	ma := masquerade{Masquerade{Domain: "a", IpAddress: "1"}, now, testProviderID}
 	mb := masquerade{Masquerade{Domain: "b", IpAddress: "2"}, now, testProviderID}
-	mc := masquerade{Masquerade{Domain: "c", IpAddress: "3"}, now, testProviderID}
+	mc := masquerade{Masquerade{Domain: "c", IpAddress: "3"}, now, ""}         // defaulted
+	md := masquerade{Masquerade{Domain: "d", IpAddress: "4"}, now, "sadcloud"} // skipped
 
 	d := makeDirect()
 	d.toCache <- ma
 	d.toCache <- mb
 	d.toCache <- mc
+	d.toCache <- md
 
 	readMasquerades := func() []masquerade {
 		var result []masquerade

--- a/cache_test.go
+++ b/cache_test.go
@@ -18,6 +18,13 @@ func TestCaching(t *testing.T) {
 	defer os.RemoveAll(dir)
 	cacheFile := filepath.Join(dir, "cachefile.1")
 
+	cloudsackID := "cloudsack"
+
+	providers := map[string]*Provider{
+		testProviderID: NewProvider(nil, "", nil, nil),
+		cloudsackID:    NewProvider(nil, "", nil, nil),
+	}
+
 	makeDirect := func() *direct {
 		d := &direct{
 			candidates:          make(chan masquerade, 1000),
@@ -26,8 +33,8 @@ func TestCaching(t *testing.T) {
 			maxCacheSize:        3,
 			cacheSaveInterval:   50 * time.Millisecond,
 			toCache:             make(chan masquerade, 1000),
-			providers:           testProviders(),
-			defaultProviderID:   testProviderID,
+			providers:           providers,
+			defaultProviderID:   cloudsackID,
 		}
 		go d.fillCache(make([]masquerade, 0), cacheFile)
 		return d
@@ -70,8 +77,10 @@ func TestCaching(t *testing.T) {
 	assert.Len(t, masquerades, 2, "Wrong number of masquerades read")
 	assert.Equal(t, "b", masquerades[0].Domain, "Wrong masquerade at position 0")
 	assert.Equal(t, "2", masquerades[0].IpAddress, "Masquerade at position 0 has wrong IpAddress")
+	assert.Equal(t, testProviderID, masquerades[0].ProviderID, "Masquerade at position 0 has wrong ProviderID")
 	assert.Equal(t, "c", masquerades[1].Domain, "Wrong masquerade at position 0")
 	assert.Equal(t, "3", masquerades[1].IpAddress, "Masquerade at position 1 has wrong IpAddress")
+	assert.Equal(t, cloudsackID, masquerades[1].ProviderID, "Masquerade at position 1 has wrong ProviderID")
 	d.closeCache()
 
 	time.Sleep(d.maxAllowedCachedAge)

--- a/direct.go
+++ b/direct.go
@@ -321,10 +321,10 @@ func (d *direct) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 		frontedHost := provider.Lookup(originHost)
 		if frontedHost == "" {
-			log.Debugf("Not translating unknown origin %s...", originHost)
+			log.Tracef("Not translating unknown origin %s...", originHost)
 			frontedHost = originHost
 		} else {
-			log.Debugf("Translated origin %s -> %s for provider %s...", originHost, frontedHost, m.ProviderID)
+			log.Tracef("Translated origin %s -> %s for provider %s...", originHost, frontedHost, m.ProviderID)
 		}
 
 		reqi, err := cloneRequestWith(req, frontedHost, getBody())

--- a/direct_test.go
+++ b/direct_test.go
@@ -1,13 +1,20 @@
 package fronted
 
 import (
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	. "github.com/getlantern/waitforserver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +40,7 @@ func doTestDomainFronting(t *testing.T, cacheFile string) {
 	client := &http.Client{
 		Transport: direct,
 	}
-	assert.True(t, doCheck(client, http.MethodPost, http.StatusAccepted, testURL))
+	assert.True(t, doCheck(client, http.MethodPost, http.StatusAccepted, pingTestURL))
 
 	direct, ok = NewDirect(30 * time.Second)
 	if !assert.True(t, ok) {
@@ -42,13 +49,13 @@ func doTestDomainFronting(t *testing.T, cacheFile string) {
 	client = &http.Client{
 		Transport: direct,
 	}
-	assert.True(t, doCheck(client, http.MethodGet, http.StatusOK, "http://d2wi0vwulmtn99.cloudfront.net/proxies.yaml.gz"))
+	assert.True(t, doCheck(client, http.MethodGet, http.StatusOK, getTestURL))
 }
 
 func TestVet(t *testing.T) {
 	pool := trustedCACerts(t)
-	for _, m := range DefaultCloudfrontMasquerades {
-		if Vet(m, pool) {
+	for _, m := range testMasquerades {
+		if Vet(m, pool, pingTestURL) {
 			return
 		}
 	}
@@ -56,15 +63,20 @@ func TestVet(t *testing.T) {
 }
 
 func TestLoadCandidates(t *testing.T) {
-	expected := make(map[Masquerade]bool, len(DefaultCloudfrontMasquerades))
-	for _, m := range DefaultCloudfrontMasquerades {
-		expected[*m] = true
+	providers := testProviders()
+
+	expected := make(map[Masquerade]bool)
+	for _, p := range providers {
+		for _, m := range p.Masquerades {
+			expected[*m] = true
+		}
 	}
 
 	d := &direct{
-		candidates: make(chan masquerade, len(DefaultCloudfrontMasquerades)),
+		candidates: make(chan masquerade, len(expected)),
 	}
-	d.loadCandidates(map[string][]*Masquerade{"cloudfront": DefaultCloudfrontMasquerades})
+
+	d.loadCandidates(providers)
 	close(d.candidates)
 
 	actual := make(map[Masquerade]bool)
@@ -76,4 +88,242 @@ func TestLoadCandidates(t *testing.T) {
 
 	assert.Equal(t, len(DefaultCloudfrontMasquerades), count, "Unexpected number of candidates")
 	assert.Equal(t, expected, actual, "Masquerades did not load as expected")
+}
+
+func TestHostAliasesBasic(t *testing.T) {
+
+	tests := []struct {
+		url            string
+		expectedResult CDNResult
+		expectedStatus int
+	}{
+		{
+			"http://abc.forbidden.com/foo/bar",
+			CDNResult{"abc.cloudsack.biz", "/foo/bar", "", "cloudsack"},
+			http.StatusAccepted,
+		},
+		{
+			"https://abc.forbidden.com/bar?x=y&z=w",
+			CDNResult{"abc.cloudsack.biz", "/bar", "x=y&z=w", "cloudsack"},
+			http.StatusAccepted,
+		},
+		{
+			"http://def.forbidden.com/foo",
+			CDNResult{"def.cloudsack.biz", "/foo", "", "cloudsack"},
+			http.StatusAccepted,
+		},
+		{
+			"https://def.forbidden.com/bar?x=y&z=w",
+			CDNResult{"def.cloudsack.biz", "/bar", "x=y&z=w", "cloudsack"},
+			http.StatusAccepted,
+		},
+		// not translated, but permitted
+		{
+			"http://fff.cloudsack.biz/foo",
+			CDNResult{"fff.cloudsack.biz", "/foo", "", "cloudsack"},
+			http.StatusAccepted,
+		},
+		{
+			"http://fff.cloudsack.biz/bar?x=y&z=w",
+			CDNResult{"fff.cloudsack.biz", "/bar", "x=y&z=w", "cloudsack"},
+			http.StatusAccepted,
+		},
+	}
+
+	cloudSack, cloudSackAddr, err := newCDN("cloudsack", "cloudsack.biz")
+	if !assert.NoError(t, err, "failed to start cloudsack cdn") {
+		return
+	}
+	defer cloudSack.Close()
+
+	masq := []*Masquerade{&Masquerade{Domain: "example.com", IpAddress: cloudSackAddr}}
+	alias := map[string]string{
+		"abc.forbidden.com": "abc.cloudsack.biz",
+		"def.forbidden.com": "def.cloudsack.biz",
+	}
+	p := NewProvider(alias, "https://ttt.cloudsack.biz/ping", masq)
+
+	certs := x509.NewCertPool()
+	certs.AddCert(cloudSack.Certificate())
+	Configure(certs, map[string]*Provider{"cloudsack": p}, "cloudsack", "")
+
+	rt, ok := NewDirect(10 * time.Second)
+	if !assert.True(t, ok, "failed to obtain direct roundtripper") {
+		return
+	}
+	client := &http.Client{Transport: rt}
+	for _, test := range tests {
+		resp, err := client.Get(test.url)
+		if !assert.NoError(t, err, "Request %s failed", test.url) {
+			continue
+		}
+		assert.Equal(t, test.expectedStatus, resp.StatusCode)
+		if !assert.NotNil(t, resp.Body) {
+			continue
+		}
+
+		var result CDNResult
+		data, err := ioutil.ReadAll(resp.Body)
+		if !assert.NoError(t, err) {
+			continue
+		}
+
+		err = json.Unmarshal(data, &result)
+		if !assert.NoError(t, err) {
+			continue
+		}
+		assert.Equal(t, test.expectedResult, result)
+	}
+
+	// this is not allowed, so masqurades are discarded and
+	// an error results...
+	_, err = client.Get("https://example.biz/baz")
+	assert.NotNil(t, err)
+}
+
+func TestHostAliasesMulti(t *testing.T) {
+
+	tests := []struct {
+		url            string
+		expectedStatus int
+		expectedPath   string
+		expectedQuery  string
+		expectedHosts  []string
+	}{
+		{
+			"http://abc.forbidden.com/foo/bar",
+			http.StatusAccepted,
+			"/foo/bar",
+			"",
+			[]string{
+				"abc.cloudsack.biz",
+				"abc.sadcloud.io",
+			},
+		},
+		{
+			"http://def.forbidden.com/bar?x=y&z=w",
+			http.StatusAccepted,
+			"/bar",
+			"x=y&z=w",
+			[]string{
+				"def.cloudsack.biz",
+				"def.sadcloud.io",
+			},
+		},
+	}
+
+	sadCloud, sadCloudAddr, err := newCDN("sadcloud", "sadcloud.io")
+	if !assert.NoError(t, err, "failed to start sadcloud cdn") {
+		return
+	}
+	defer sadCloud.Close()
+
+	cloudSack, cloudSackAddr, err := newCDN("cloudsack", "cloudsack.biz")
+	if !assert.NoError(t, err, "failed to start cloudsack cdn") {
+		return
+	}
+	defer cloudSack.Close()
+
+	masq1 := []*Masquerade{&Masquerade{Domain: "example.com", IpAddress: cloudSackAddr}}
+	alias1 := map[string]string{
+		"abc.forbidden.com": "abc.cloudsack.biz",
+		"def.forbidden.com": "def.cloudsack.biz",
+	}
+	p1 := NewProvider(alias1, "https://ttt.cloudsack.biz/ping", masq1)
+
+	masq2 := []*Masquerade{&Masquerade{Domain: "example.com", IpAddress: sadCloudAddr}}
+	alias2 := map[string]string{
+		"abc.forbidden.com": "abc.sadcloud.io",
+		"def.forbidden.com": "def.sadcloud.io",
+	}
+	p2 := NewProvider(alias2, "https://ttt.sadcloud.io/ping", masq2)
+
+	certs := x509.NewCertPool()
+	certs.AddCert(cloudSack.Certificate())
+	certs.AddCert(sadCloud.Certificate())
+
+	providers := map[string]*Provider{
+		"cloudsack": p1,
+		"sadcloud":  p2,
+	}
+
+	Configure(certs, providers, "cloudsack", "")
+	rt, ok := NewDirect(10 * time.Second)
+	if !assert.True(t, ok, "failed to obtain direct roundtripper") {
+		return
+	}
+	client := &http.Client{Transport: rt}
+
+	providerCounts := make(map[string]int)
+
+	for i := 0; i < 10; i++ {
+		for _, test := range tests {
+			resp, err := client.Get(test.url)
+			if !assert.NoError(t, err, "Request %s failed", test.url) {
+				continue
+			}
+			assert.Equal(t, test.expectedStatus, resp.StatusCode)
+			if !assert.NotNil(t, resp.Body) {
+				continue
+			}
+
+			var result CDNResult
+			data, err := ioutil.ReadAll(resp.Body)
+			if !assert.NoError(t, err) {
+				continue
+			}
+
+			err = json.Unmarshal(data, &result)
+			if !assert.NoError(t, err) {
+				continue
+			}
+			assert.Contains(t, test.expectedHosts, result.Host)
+			assert.Equal(t, test.expectedQuery, result.Query)
+			assert.Equal(t, test.expectedPath, result.Path)
+
+			providerCounts[result.Provider] += 1
+		}
+	}
+
+	assert.True(t, providerCounts["cloudsack"] > 1)
+	assert.True(t, providerCounts["sadcloud"] > 1)
+}
+
+type CDNResult struct {
+	Host, Path, Query, Provider string
+}
+
+func newCDN(providerID, domain string) (*httptest.Server, string, error) {
+	allowedSuffix := fmt.Sprintf(".%s", domain)
+	srv := httptest.NewTLSServer(
+		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			dump, err := httputil.DumpRequest(req, true)
+			if err != nil {
+				log.Errorf("Failed to dump request: %s", err)
+			} else {
+				log.Debugf("(%s) CDN Request: %s", domain, dump)
+			}
+
+			vhost := req.Host
+			if strings.HasSuffix(vhost, allowedSuffix) {
+				body, _ := json.Marshal(&CDNResult{
+					Host:     vhost,
+					Path:     req.URL.Path,
+					Query:    req.URL.RawQuery,
+					Provider: providerID,
+				})
+				rw.WriteHeader(http.StatusAccepted)
+				rw.Write(body)
+			} else {
+				log.Debugf("(%s) Rejecting request with host = %q", domain, vhost)
+				rw.WriteHeader(http.StatusForbidden)
+			}
+		}))
+	addr := srv.Listener.Addr().String()
+	log.Debugf("Waiting for origin server at %s...", addr)
+	if err := WaitForServer("tcp", addr, 10*time.Second); err != nil {
+		return nil, "", err
+	}
+	log.Debugf("Started %s CDN", domain)
+	return srv, addr, nil
 }

--- a/masquerade.go
+++ b/masquerade.go
@@ -1,12 +1,19 @@
 package fronted
 
 import (
+	"fmt"
+	"net"
+	"net/http"
 	"strings"
 	"time"
 )
 
 const (
 	NumWorkers = 10 // number of worker goroutines for verifying
+)
+
+var (
+	defaultValidator = NewStatusCodeValidator([]int{403})
 )
 
 // CA represents a certificate authority
@@ -42,14 +49,20 @@ type Provider struct {
 	// Url used to vet masquerades for this provider
 	TestURL     string
 	Masquerades []*Masquerade
+	// Optional response validator used to determine whether
+	// fronting succeeded for this provider. If the validator
+	// detects a failure for a given masquerade, it is discarded.
+	// The default validator is used if nil.
+	Validator ResponseValidator
 }
 
-// Create a DirectProvider with the given details
-func NewProvider(hosts map[string]string, testURL string, masquerades []*Masquerade) *Provider {
+// Create a Provider with the given details
+func NewProvider(hosts map[string]string, testURL string, masquerades []*Masquerade, validator ResponseValidator) *Provider {
 	d := &Provider{
 		HostAliases: make(map[string]string),
 		TestURL:     testURL,
 		Masquerades: make([]*Masquerade, 0, len(masquerades)),
+		Validator:   validator,
 	}
 	for k, v := range hosts {
 		d.HostAliases[strings.ToLower(k)] = v
@@ -60,6 +73,42 @@ func NewProvider(hosts map[string]string, testURL string, masquerades []*Masquer
 	return d
 }
 
+// Lookup the host alias for the given hostname for this provider
 func (p *Provider) Lookup(hostname string) string {
+	// only consider the host porition if given a port as well.
+	if h, _, err := net.SplitHostPort(hostname); err == nil {
+		hostname = h
+	}
 	return p.HostAliases[strings.ToLower(hostname)]
+}
+
+// Validate a fronted response.  Returns an error if the
+// response failed to reach the origin, eg if the request
+// was rejected by the provider.
+func (p *Provider) ValidateResponse(res *http.Response) error {
+	if p.Validator != nil {
+		return p.Validator(res)
+	} else {
+		return defaultValidator(res)
+	}
+}
+
+// A validator for fronted responses.  Returns an error if the
+// response failed to reach the origin, eg if the request
+// was rejected by the provider.
+type ResponseValidator func(*http.Response) error
+
+// Create a new ResponseValidator that rejects any response with
+// a given list of http status codes.
+func NewStatusCodeValidator(reject []int) ResponseValidator {
+	bad := make(map[int]bool)
+	for _, code := range reject {
+		bad[code] = true
+	}
+	return func(res *http.Response) error {
+		if bad[res.StatusCode] {
+			return fmt.Errorf("response status %d: %v", res.StatusCode, res.Status)
+		}
+		return nil
+	}
 }

--- a/masquerade.go
+++ b/masquerade.go
@@ -1,6 +1,7 @@
 package fronted
 
 import (
+	"strings"
 	"time"
 )
 
@@ -29,4 +30,36 @@ type masquerade struct {
 	Masquerade
 	// lastVetted: the most recent time at which this Masquerade was vetted
 	LastVetted time.Time
+	// id of DirectProvider that this masquerade is provided by
+	ProviderID string
+}
+
+// A Direct fronting provider configuration.
+type Provider struct {
+	// Specific hostname mappings used for this provider.
+	// remaps certain requests to provider specific host names.
+	HostAliases map[string]string
+	// Url used to vet masquerades for this provider
+	TestURL     string
+	Masquerades []*Masquerade
+}
+
+// Create a DirectProvider with the given details
+func NewProvider(hosts map[string]string, testURL string, masquerades []*Masquerade) *Provider {
+	d := &Provider{
+		HostAliases: make(map[string]string),
+		TestURL:     testURL,
+		Masquerades: make([]*Masquerade, 0, len(masquerades)),
+	}
+	for k, v := range hosts {
+		d.HostAliases[strings.ToLower(k)] = v
+	}
+	for _, m := range masquerades {
+		d.Masquerades = append(d.Masquerades, &Masquerade{Domain: m.Domain, IpAddress: m.IpAddress})
+	}
+	return d
+}
+
+func (p *Provider) Lookup(hostname string) string {
+	return p.HostAliases[strings.ToLower(hostname)]
 }

--- a/test_support.go
+++ b/test_support.go
@@ -10,7 +10,6 @@ import (
 var (
 	testProviderID  = "cloudfront"
 	pingTestURL     = "http://d157vud77ygy87.cloudfront.net/ping"
-	getTestURL      = "http://d2wi0vwulmtn99.cloudfront.net/proxies.yaml.gz"
 	testHosts       = map[string]string(nil)
 	testMasquerades = DefaultCloudfrontMasquerades
 )
@@ -48,12 +47,12 @@ func trustedCACerts(t *testing.T) *x509.CertPool {
 
 func testProviders() map[string]*Provider {
 	return map[string]*Provider{
-		testProviderID: NewProvider(testHosts, pingTestURL, testMasquerades),
+		testProviderID: NewProvider(testHosts, pingTestURL, testMasquerades, nil),
 	}
 }
 
 func testProvidersWithHosts(hosts map[string]string) map[string]*Provider {
 	return map[string]*Provider{
-		testProviderID: NewProvider(hosts, pingTestURL, testMasquerades),
+		testProviderID: NewProvider(hosts, pingTestURL, testMasquerades, nil),
 	}
 }

--- a/test_support.go
+++ b/test_support.go
@@ -27,6 +27,12 @@ func ConfigureCachingForTest(t *testing.T, cacheFile string) {
 	Configure(certs, p, testProviderID, cacheFile)
 }
 
+func ConfigureHostAlaisesForTest(t *testing.T, hosts map[string]string) {
+	certs := trustedCACerts(t)
+	p := testProvidersWithHosts(hosts)
+	Configure(certs, p, testProviderID, "")
+}
+
 func trustedCACerts(t *testing.T) *x509.CertPool {
 	certs := make([]string, 0, len(DefaultTrustedCAs))
 	for _, ca := range DefaultTrustedCAs {
@@ -43,5 +49,11 @@ func trustedCACerts(t *testing.T) *x509.CertPool {
 func testProviders() map[string]*Provider {
 	return map[string]*Provider{
 		testProviderID: NewProvider(testHosts, pingTestURL, testMasquerades),
+	}
+}
+
+func testProvidersWithHosts(hosts map[string]string) map[string]*Provider {
+	return map[string]*Provider{
+		testProviderID: NewProvider(hosts, pingTestURL, testMasquerades),
 	}
 }

--- a/test_support.go
+++ b/test_support.go
@@ -7,6 +7,14 @@ import (
 	"github.com/getlantern/keyman"
 )
 
+var (
+	testProviderID  = "cloudfront"
+	pingTestURL     = "http://d157vud77ygy87.cloudfront.net/ping"
+	getTestURL      = "http://d2wi0vwulmtn99.cloudfront.net/proxies.yaml.gz"
+	testHosts       = map[string]string(nil)
+	testMasquerades = DefaultCloudfrontMasquerades
+)
+
 // ConfigureForTest configures fronted for testing using default masquerades and
 // certificate authorities.
 func ConfigureForTest(t *testing.T) {
@@ -15,9 +23,8 @@ func ConfigureForTest(t *testing.T) {
 
 func ConfigureCachingForTest(t *testing.T, cacheFile string) {
 	certs := trustedCACerts(t)
-	m := make(map[string][]*Masquerade)
-	m["cloudfront"] = DefaultCloudfrontMasquerades
-	Configure(certs, m, cacheFile)
+	p := testProviders()
+	Configure(certs, p, testProviderID, cacheFile)
 }
 
 func trustedCACerts(t *testing.T) *x509.CertPool {
@@ -31,4 +38,10 @@ func trustedCACerts(t *testing.T) *x509.CertPool {
 		t.Fatalf("Unable to set up cert pool")
 	}
 	return pool
+}
+
+func testProviders() map[string]*Provider {
+	return map[string]*Provider{
+		testProviderID: NewProvider(testHosts, pingTestURL, testMasquerades),
+	}
 }


### PR DESCRIPTION
Allows configuration of additional per provider details.  In particular a table of host aliases for translating to particular provider-specific hostnames.

Not ready for merge / review without other changes