### PR TITLE
Expire configs to reset session tickets as necessary

### DIFF
--- a/direct.go
+++ b/direct.go
@@ -21,6 +21,7 @@ import (
 	"github.com/getlantern/idletiming"
 	"github.com/getlantern/netx"
 	"github.com/getlantern/tlsdialer"
+	tls "github.com/refraction-networking/utls"
 )
 
 const (
@@ -536,11 +537,10 @@ func (d *direct) tlsConfig(m *Masquerade) *tls.Config {
 
 // expireTLSConfig expires a TLS config. This is useful for things like when we see a
 // tls.newSessionTicketMsg from the server.
-func (d *direct) expireTLSConfig(m *Masquerade) *tls.Config {
+func (d *direct) expireTLSConfig(m *Masquerade) {
 	d.tlsConfigsMutex.Lock()
 	defer d.tlsConfigsMutex.Unlock()
-
-	delete(d.tlsConfig, m.Domain)
+	delete(d.tlsConfigs, m.Domain)
 }
 
 func httpTransport(conn net.Conn, clientSessionCache gtls.ClientSessionCache) http.RoundTripper {

--- a/direct.go
+++ b/direct.go
@@ -21,7 +21,6 @@ import (
 	"github.com/getlantern/idletiming"
 	"github.com/getlantern/netx"
 	"github.com/getlantern/tlsdialer"
-	"github.com/refraction-networking/utls"
 )
 
 const (
@@ -462,8 +461,17 @@ func (d *direct) doDial(m *Masquerade) (conn net.Conn, retriable bool, err error
 		// will just keep failing and will waste connections. We can't access the underlying
 		// error at this point so just look for "certificate" and "handshake".
 		if strings.Contains(err.Error(), "certificate") || strings.Contains(err.Error(), "handshake") {
-			log.Debugf("Not re-adding candidate that failed on error '%v'", err.Error())
-			retriable = false
+			if strings.Contains(err.Error(), "tls.newSessionTicketMsg") {
+				// See https://github.com/getlantern/lantern-internal/issues/2265
+				// We sometimes see at least CloudFront servers requesting new session tickets. We should
+				// be able to just expire the old one and request a new one.
+				log.Debugf("Expiring config on tls.newSessionTicketMsg error '%v'", err.Error())
+				d.expireTLSConfig(m)
+				retriable = true
+			} else {
+				log.Debugf("Not re-adding candidate that failed on error '%v'", err.Error())
+				retriable = false
+			}
 		} else {
 			log.Tracef("Unexpected error dialing, keeping masquerade: %v", err)
 			retriable = true
@@ -524,6 +532,15 @@ func (d *direct) tlsConfig(m *Masquerade) *tls.Config {
 	}
 
 	return tlsConfig
+}
+
+// expireTLSConfig expires a TLS config. This is useful for things like when we see a
+// tls.newSessionTicketMsg from the server.
+func (d *direct) expireTLSConfig(m *Masquerade) *tls.Config {
+	d.tlsConfigsMutex.Lock()
+	defer d.tlsConfigsMutex.Unlock()
+
+	delete(d.tlsConfig, m.Domain)
 }
 
 func httpTransport(conn net.Conn, clientSessionCache gtls.ClientSessionCache) http.RoundTripper {


### PR DESCRIPTION
This closes https://github.com/getlantern/lantern-internal/issues/2265 to reset the session ticket cache for given domains, as Go's TLS does not seem to support tls.newSessionTicketMsg