### PR TITLE
allow separate fronting contexts, access to underlying connection, passthrough

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -99,16 +99,6 @@ func (d *direct) fillCache(cache []masquerade, cacheFile string) {
 	}
 }
 
-// CloseCache closes any existing file cache.
-func CloseCache() {
-	_existing, ok := _instance.Get(0)
-	if ok && _existing != nil {
-		existing := _existing.(*direct)
-		log.Debug("Closing cache from existing instance")
-		existing.closeCache()
-	}
-}
-
 func (d *direct) closeCache() {
 	d.toCache <- fillSentinel
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -21,8 +21,8 @@ func TestCaching(t *testing.T) {
 	cloudsackID := "cloudsack"
 
 	providers := map[string]*Provider{
-		testProviderID: NewProvider(nil, "", nil, nil),
-		cloudsackID:    NewProvider(nil, "", nil, nil),
+		testProviderID: NewProvider(nil, "", nil, nil, nil),
+		cloudsackID:    NewProvider(nil, "", nil, nil, nil),
 	}
 
 	makeDirect := func() *direct {

--- a/context.go
+++ b/context.go
@@ -1,11 +1,13 @@
 package fronted
 
-import "crypto/x509"
-import "fmt"
-import "net/http"
-import "time"
+import (
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"time"
 
-import "github.com/getlantern/eventual"
+	"github.com/getlantern/eventual"
+)
 
 var (
 	defaultContext = NewFrontingContext("default")

--- a/context.go
+++ b/context.go
@@ -1,0 +1,177 @@
+package fronted
+
+import "crypto/x509"
+import "fmt"
+import "net/http"
+import "time"
+import "sync"
+
+import "github.com/getlantern/eventual"
+
+var (
+	contextsMx       sync.Mutex
+	contexts         = make(map[string]*frontingContext)
+	defaultContextID = "default"
+)
+
+// Configure sets the masquerades to use, the trusted root CAs, and the
+// cache file for caching masquerades to set up direct domain fronting
+// in the default context.
+//
+// defaultProviderID is used when a masquerade without a provider is
+// encountered (eg in a cache file)
+func Configure(pool *x509.CertPool, providers map[string]*Provider, defaultProviderID string, cacheFile string) {
+	ConfigureContext(defaultContextID, pool, providers, defaultProviderID, cacheFile)
+}
+
+// ConfigureContext establishes a new independent fronting
+// configuration for each id.  Masquerades are chosen, vetted and
+// used separately from the default configuration and other
+// fronting contexts.
+func ConfigureContext(id string, pool *x509.CertPool, providers map[string]*Provider, defaultProviderID string, cacheFile string) {
+	fctx := getOrCreateContext(id)
+	if err := fctx.Configure(pool, providers, defaultProviderID, cacheFile); err != nil {
+		log.Errorf("Error configuring fronting %s context: %s!!", id, err)
+	}
+}
+
+// NewDirect creates a new http.RoundTripper that does direct domain fronting
+// using the default context. If it can't obtain a working masquerade within
+// the given timeout, it will return nil/false.
+func NewDirect(timeout time.Duration) (http.RoundTripper, bool) {
+	return NewDirectContext(defaultContextID, timeout)
+}
+
+func NewDirectContext(id string, timeout time.Duration) (http.RoundTripper, bool) {
+	return getOrCreateContext(id).NewDirect(timeout)
+}
+
+// CloseCache closes any existing cache file.
+func CloseCache() {
+	contextsMx.Lock()
+	ids := make([]string, 0, len(contexts))
+	for id := range contexts {
+		ids = append(ids, id)
+	}
+	contextsMx.Unlock()
+
+	for _, id := range ids {
+		CloseCacheContext(id)
+	}
+}
+
+func CloseCacheContext(id string) {
+	getOrCreateContext(id).CloseCache()
+}
+
+func getOrCreateContext(id string) *frontingContext {
+	contextsMx.Lock()
+	fctx := contexts[id]
+	if fctx == nil {
+		fctx = &frontingContext{
+			id:       id,
+			instance: eventual.NewValue(),
+		}
+		contexts[id] = fctx
+	}
+	contextsMx.Unlock()
+	return fctx
+}
+
+type frontingContext struct {
+	id       string
+	instance eventual.Value
+}
+
+// Configure sets the masquerades to use, the trusted root CAs, and the
+// cache file for caching masquerades to set up direct domain fronting.
+// defaultProviderID is used when a masquerade without a provider is
+// encountered (eg in a cache file)
+func (fctx *frontingContext) Configure(pool *x509.CertPool, providers map[string]*Provider, defaultProviderID string, cacheFile string) error {
+	log.Tracef("Configuring fronted %s context", fctx.id)
+
+	if providers == nil || len(providers) == 0 {
+		return fmt.Errorf("No fronted providers for %s context.", fctx.id)
+	}
+
+	_existing, ok := fctx.instance.Get(0)
+	if ok && _existing != nil {
+		existing := _existing.(*direct)
+		log.Debugf("Closing cache from existing instance for %s context", fctx.id)
+		existing.closeCache()
+	}
+
+	size := 0
+	for _, p := range providers {
+		size += len(p.Masquerades)
+	}
+
+	if size == 0 {
+		return fmt.Errorf("No masquerades for %s context.", fctx.id)
+	}
+
+	d := &direct{
+		certPool:            pool,
+		candidates:          make(chan masquerade, size),
+		masquerades:         make(chan masquerade, size),
+		maxAllowedCachedAge: defaultMaxAllowedCachedAge,
+		maxCacheSize:        defaultMaxCacheSize,
+		cacheSaveInterval:   defaultCacheSaveInterval,
+		toCache:             make(chan masquerade, defaultMaxCacheSize),
+		defaultProviderID:   defaultProviderID,
+		providers:           make(map[string]*Provider),
+		ready:               make(chan struct{}),
+	}
+
+	// copy providers
+	for k, p := range providers {
+		d.providers[k] = NewProvider(p.HostAliases, p.TestURL, p.Masquerades, p.Validator, p.PassthroughDomains)
+	}
+
+	numberToVet := numberToVetInitially
+	if cacheFile != "" {
+		numberToVet -= d.initCaching(cacheFile)
+	}
+
+	d.loadCandidates(d.providers)
+	if numberToVet > 0 {
+		d.vet(numberToVet)
+	} else {
+		log.Debugf("Not vetting any masquerades for %s context because we have enough cached ones", fctx.id)
+		d.signalReady()
+	}
+	fctx.instance.Set(d)
+	return nil
+}
+
+// NewDirect creates a new http.RoundTripper that does direct domain fronting.
+// If it can't obtain a working masquerade within the given timeout, it will
+// return nil/false.
+func (fctx *frontingContext) NewDirect(timeout time.Duration) (http.RoundTripper, bool) {
+	start := time.Now()
+	instance, ok := fctx.instance.Get(timeout)
+	if !ok {
+		log.Errorf("No DirectHttpClient available within %v for context %s", timeout, fctx.id)
+		return nil, false
+	}
+	remaining := timeout - time.Since(start)
+
+	// Wait to be signalled that at least one masquerade has been vetted...
+	select {
+	case <-instance.(*direct).ready:
+		return instance.(http.RoundTripper), true
+	case <-time.After(remaining):
+		log.Errorf("No DirectHttpClient available within %v", timeout)
+		return nil, false
+	}
+}
+
+// CloseCache closes any existing cache file in the default contexxt.
+func (fctx *frontingContext) CloseCache() {
+	_existing, ok := fctx.instance.Get(0)
+	if ok && _existing != nil {
+		existing := _existing.(*direct)
+		log.Debugf("Closing cache from existing instance in %s context", fctx.id)
+		existing.closeCache()
+	}
+}

--- a/direct.go
+++ b/direct.go
@@ -15,7 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/getlantern/eventual"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/idletiming"
 	"github.com/getlantern/netx"
@@ -32,8 +31,7 @@ const (
 )
 
 var (
-	log       = golog.LoggerFor("fronted")
-	_instance = eventual.NewValue()
+	log = golog.LoggerFor("fronted")
 )
 
 // direct is an implementation of http.RoundTripper
@@ -49,63 +47,6 @@ type direct struct {
 	providers           map[string]*Provider
 	ready               chan struct{}
 	readyOnce           sync.Once
-}
-
-// Configure sets the masquerades to use, the trusted root CAs, and the
-// cache file for caching masquerades to set up direct domain fronting.
-// defaultProviderID is used when a masquerade without a provider is
-// encountered (eg in a cache file)
-func Configure(pool *x509.CertPool, providers map[string]*Provider, defaultProviderID string, cacheFile string) {
-	log.Trace("Configuring fronted")
-
-	if providers == nil || len(providers) == 0 {
-		log.Errorf("No fronted providers!!")
-		return
-	}
-
-	CloseCache()
-
-	size := 0
-	for _, p := range providers {
-		size += len(p.Masquerades)
-	}
-
-	if size == 0 {
-		log.Errorf("No masquerades!!")
-		return
-	}
-
-	d := &direct{
-		certPool:            pool,
-		candidates:          make(chan masquerade, size),
-		masquerades:         make(chan masquerade, size),
-		maxAllowedCachedAge: defaultMaxAllowedCachedAge,
-		maxCacheSize:        defaultMaxCacheSize,
-		cacheSaveInterval:   defaultCacheSaveInterval,
-		toCache:             make(chan masquerade, defaultMaxCacheSize),
-		defaultProviderID:   defaultProviderID,
-		providers:           make(map[string]*Provider),
-		ready:               make(chan struct{}),
-	}
-
-	// copy providers
-	for k, p := range providers {
-		d.providers[k] = NewProvider(p.HostAliases, p.TestURL, p.Masquerades, p.Validator)
-	}
-
-	numberToVet := numberToVetInitially
-	if cacheFile != "" {
-		numberToVet -= d.initCaching(cacheFile)
-	}
-
-	d.loadCandidates(d.providers)
-	if numberToVet > 0 {
-		d.vet(numberToVet)
-	} else {
-		log.Debug("Not vetting any masquerades because we have enough cached ones")
-		d.signalReady()
-	}
-	_instance.Set(d)
 }
 
 func (d *direct) loadCandidates(initial map[string]*Provider) {
@@ -241,31 +182,17 @@ func doCheck(client *http.Client, method string, expectedStatus int, u string) b
 	return true
 }
 
-// NewDirect creates a new http.RoundTripper that does direct domain fronting.
-// If it can't obtain a working masquerade within the given timeout, it will
-// return nil/false.
-func NewDirect(timeout time.Duration) (http.RoundTripper, bool) {
-	start := time.Now()
-	instance, ok := _instance.Get(timeout)
-	if !ok {
-		log.Errorf("No DirectHttpClient available within %v", timeout)
-		return nil, false
-	}
-	remaining := timeout - time.Since(start)
-
-	// Wait to be signalled that at least one masquerade has been vetted...
-	select {
-	case <-instance.(*direct).ready:
-		return instance.(http.RoundTripper), true
-	case <-time.After(remaining):
-		log.Errorf("No DirectHttpClient available within %v", timeout)
-		return nil, false
-	}
-}
-
 // Do continually retries a given request until it succeeds because some
 // fronting providers will return a 403 for some domains.
 func (d *direct) RoundTrip(req *http.Request) (*http.Response, error) {
+	res, _, err := d.RoundTripHijack(req)
+	return res, err
+}
+
+// Do continually retries a given request until it succeeds because some
+// fronting providers will return a 403 for some domains.  Also return the
+// underlying net.Conn established.
+func (d *direct) RoundTripHijack(req *http.Request) (*http.Response, net.Conn, error) {
 	isIdempotent := req.Method != http.MethodPost && req.Method != http.MethodPatch
 
 	originHost := req.URL.Hostname()
@@ -276,7 +203,7 @@ func (d *direct) RoundTrip(req *http.Request) (*http.Response, error) {
 		// store body in-memory to be able to replay it if necessary
 		body, err = ioutil.ReadAll(req.Body)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to read request body: %v", err)
+			return nil, nil, fmt.Errorf("Unable to read request body: %v", err)
 		}
 	}
 
@@ -304,7 +231,7 @@ func (d *direct) RoundTrip(req *http.Request) (*http.Response, error) {
 		conn, m, masqueradeGood, err := d.dial()
 		if err != nil {
 			// unable to find good masquerade, fail
-			return nil, err
+			return nil, nil, err
 		}
 		provider := d.providerFor(m)
 		if provider == nil {
@@ -318,7 +245,7 @@ func (d *direct) RoundTrip(req *http.Request) (*http.Response, error) {
 			// so it is returned as good.
 			conn.Close()
 			masqueradeGood(true)
-			return nil, fmt.Errorf("No alias for host %s", originHost)
+			return nil, nil, fmt.Errorf("No alias for host %s", originHost)
 		}
 		log.Tracef("Translated origin %s -> %s for provider %s...", originHost, frontedHost, m.ProviderID)
 
@@ -346,10 +273,10 @@ func (d *direct) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 
 		masqueradeGood(true)
-		return resp, nil
+		return resp, conn, nil
 	}
 
-	return nil, errors.New("Could not complete request even with retries")
+	return nil, nil, errors.New("Could not complete request even with retries")
 }
 
 func cloneRequestWith(req *http.Request, frontedHost string, body io.ReadCloser) (*http.Request, error) {

--- a/direct_test.go
+++ b/direct_test.go
@@ -370,21 +370,21 @@ func TestPassthrough(t *testing.T) {
 		expectedStatus int
 	}{
 		{
-			"http://fff.cloudsack.biz/foo",
+			"http://fff.ok.cloudsack.biz/foo",
 			headersIn,
-			CDNResult{"fff.cloudsack.biz", "/foo", "", "cloudsack", headersOut},
+			CDNResult{"fff.ok.cloudsack.biz", "/foo", "", "cloudsack", headersOut},
 			http.StatusAccepted,
 		},
 		{
-			"http://cloudsack.biz/bar",
+			"http://abc.cloudsack.biz/bar",
 			headersIn,
-			CDNResult{"cloudsack.biz", "/bar", "", "cloudsack", headersOut},
+			CDNResult{"abc.cloudsack.biz", "/bar", "", "cloudsack", headersOut},
 			http.StatusAccepted,
 		},
 		{
-			"http://XYZ.ZyZ.CloudSack.BiZ/bar",
+			"http://XYZ.ZyZ.OK.CloudSack.BiZ/bar",
 			headersIn,
-			CDNResult{"xyz.zyz.cloudsack.biz", "/bar", "", "cloudsack", headersOut},
+			CDNResult{"xyz.zyz.ok.cloudsack.biz", "/bar", "", "cloudsack", headersOut},
 			http.StatusAccepted,
 		},
 	}
@@ -394,12 +394,24 @@ func TestPassthrough(t *testing.T) {
 		expectedError string
 	}{
 		{
-			"http://www.notcloudsack.biz",
-			"Get http://www.notcloudsack.biz: No alias for host www.notcloudsack.biz",
+			"http://www.notok.cloudsack.biz",
+			"Get http://www.notok.cloudsack.biz: No alias for host www.notok.cloudsack.biz",
 		},
 		{
-			"http://notcloudsack.biz",
-			"Get http://notcloudsack.biz: No alias for host notcloudsack.biz",
+			"http://ok.cloudsack.biz",
+			"Get http://ok.cloudsack.biz: No alias for host ok.cloudsack.biz",
+		},
+		{
+			"http://www.abc.cloudsack.biz",
+			"Get http://www.abc.cloudsack.biz: No alias for host www.abc.cloudsack.biz",
+		},
+		{
+			"http://noabc.cloudsack.biz",
+			"Get http://noabc.cloudsack.biz: No alias for host noabc.cloudsack.biz",
+		},
+		{
+			"http://cloudsack.biz",
+			"Get http://cloudsack.biz: No alias for host cloudsack.biz",
 		},
 		{
 			"https://www.google.com",
@@ -415,7 +427,7 @@ func TestPassthrough(t *testing.T) {
 
 	masq := []*Masquerade{&Masquerade{Domain: "example.com", IpAddress: cloudSackAddr}}
 	alias := map[string]string{}
-	passthrough := []string{"cloudsack.biz"}
+	passthrough := []string{"*.ok.cloudsack.biz", "abc.cloudsack.biz"}
 	p := NewProvider(alias, "https://ttt.cloudsack.biz/ping", masq, nil, passthrough)
 
 	certs := x509.NewCertPool()

--- a/test_support.go
+++ b/test_support.go
@@ -47,12 +47,12 @@ func trustedCACerts(t *testing.T) *x509.CertPool {
 
 func testProviders() map[string]*Provider {
 	return map[string]*Provider{
-		testProviderID: NewProvider(testHosts, pingTestURL, testMasquerades, nil),
+		testProviderID: NewProvider(testHosts, pingTestURL, testMasquerades, nil, nil),
 	}
 }
 
 func testProvidersWithHosts(hosts map[string]string) map[string]*Provider {
 	return map[string]*Provider{
-		testProviderID: NewProvider(hosts, pingTestURL, testMasquerades, nil),
+		testProviderID: NewProvider(hosts, pingTestURL, testMasquerades, nil, nil),
 	}
 }


### PR DESCRIPTION
A few changes to support wss domain fronting. 
* Allows establishing separate contexts for vetting and obtaining masquerades. 
* Allows exposing the underlying net.Conn established to service an http.Request
* Allows a set of "passthough" domains for a provider that are not expected to be aliased (eg *.cloudfront.net for cloudfront) 