### PR TITLE
Return RoundTripper even if we fail to vet masquerades by the given t…

### DIFF
--- a/direct.go
+++ b/direct.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"sync"
 	"time"
 
 	tls "github.com/refraction-networking/utls"
@@ -48,8 +47,6 @@ type direct struct {
 	toCache             chan *cacheOp
 	defaultProviderID   string
 	providers           map[string]*Provider
-	ready               chan struct{}
-	readyOnce           sync.Once
 	clientHelloID       tls.ClientHelloID
 }
 
@@ -76,12 +73,6 @@ func (d *direct) loadCandidates(initial map[string]*Provider) {
 			d.candidates <- masquerade{Masquerade: *c, ProviderID: key}
 		}
 	}
-}
-
-func (d *direct) signalReady() {
-	d.readyOnce.Do(func() {
-		close(d.ready)
-	})
 }
 
 func (d *direct) providerFor(m *masquerade) *Provider {
@@ -156,9 +147,6 @@ func (d *direct) vetOne() bool {
 	}
 
 	log.Trace("Finished vetting one")
-	// signal that at least one
-	// masquerade has been vetted successfully.
-	d.signalReady()
 	return false
 }
 

--- a/direct_test.go
+++ b/direct_test.go
@@ -83,7 +83,7 @@ func doTestDomainFronting(t *testing.T, cacheFile string, expectedMasqueradesAtE
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
-	require.Equal(t, expectedMasqueradesAtEnd, masqueradesAtEnd)
+	require.GreaterOrEqual(t, masqueradesAtEnd, expectedMasqueradesAtEnd)
 	return masqueradesAtEnd
 }
 
@@ -517,6 +517,9 @@ func TestCustomValidators(t *testing.T) {
 		}
 
 		Configure(certs, providers, "sadcloud", "")
+
+		// Wait a while for vetting to finish
+		time.Sleep(5 * time.Second)
 	}
 
 	// This error indicates that the validator has discarded all masquerades.

--- a/direct_test.go
+++ b/direct_test.go
@@ -60,6 +60,7 @@ func doTestDomainFronting(t *testing.T, cacheFile string, expectedMasqueradesAtE
 
 	client := &http.Client{
 		Transport: transport,
+		Timeout:   5 * time.Second,
 	}
 	require.True(t, doCheck(client, http.MethodPost, http.StatusAccepted, pingURL))
 
@@ -108,15 +109,14 @@ func TestLoadCandidates(t *testing.T) {
 	}
 
 	d := &direct{
-		candidates: make(chan masquerade, len(expected)),
+		masquerades: make(sortedMasquerades, 0, len(expected)),
 	}
 
 	d.loadCandidates(providers)
-	close(d.candidates)
 
 	actual := make(map[Masquerade]bool)
 	count := 0
-	for m := range d.candidates {
+	for _, m := range d.masquerades {
 		actual[Masquerade{m.Domain, m.IpAddress}] = true
 		count++
 	}
@@ -356,8 +356,7 @@ func TestHostAliasesMulti(t *testing.T) {
 		}
 	}
 
-	assert.True(t, providerCounts["cloudsack"] > 1)
-	assert.True(t, providerCounts["sadcloud"] > 1)
+	assert.True(t, providerCounts["cloudsack"]+providerCounts["sadcloud"] > 2)
 }
 
 func TestPassthrough(t *testing.T) {
@@ -517,15 +516,12 @@ func TestCustomValidators(t *testing.T) {
 		}
 
 		Configure(certs, providers, "sadcloud", "")
-
-		// Wait a while for vetting to finish
-		time.Sleep(5 * time.Second)
 	}
 
 	// This error indicates that the validator has discarded all masquerades.
 	// Each test starts with one masquerade, which is vetted during the
 	// call to NewDirect.
-	masqueradesExhausted := fmt.Sprintf(`Get "%v": could not dial any masquerade?`, testURL)
+	masqueradesExhausted := fmt.Sprintf(`Get "%v": could not complete request even with retries`, testURL)
 
 	tests := []struct {
 		responseCode  int
@@ -609,7 +605,7 @@ func TestCustomValidators(t *testing.T) {
 
 		res, err := client.Do(req)
 		if test.expectedError == "" {
-			if !assert.Nil(t, err) {
+			if !assert.NoError(t, err) {
 				continue
 			}
 			assert.Equal(t, test.responseCode, res.StatusCode, "Failed to force response status code")


### PR DESCRIPTION
…imeout

For getlantern/engineering#180

The short version is that if the network is down when we bootstrap fronted, it will never work even after the network recovers.

What's happening is this:

1. When starting Lantern with no working Internet connection, fronted quickly blows through all 2000 configured masquerades and fails to vet any
2. It then fails to return a RoundTripper
3. Subsequent calls to obtain a RoundTripper time out because all masquerades failed to vet and so we never get a vetted masquerade
4. Even if connectivity is restored, we don't ever get any vetted masquerades, to fronted remains broken

The solution is to not bother waiting for vetted masquerades before returning the RoundTripper. When someone then attempts to dial with it, if it has successfully vetted masquerades, those will be preferred, but if it hasn't yet vetted any, we'll dial with a random candidate, which at least has a hope of succeeding once connectivity is restored.

I tested this by following the steps in getlantern/engineering#180 and was able to verify that the fix worked. It also seems to just generally speed up startup if we're starting with decent network connectivity.

Note that even though the logged ticket is for Android, this affects Desktop and iOS as well.