### PR TITLE
Re-sort masquerades while iterating to always dial the best

### DIFF
--- a/fronted_test.go
+++ b/fronted_test.go
@@ -956,7 +956,7 @@ func TestMasqueradeToTry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &fronted{}
 			masquerades := tt.masquerades.sortedCopy()
-			result := f.masqueradeToTry(masquerades, tt.triedMasquerades)
+			result, _ := f.masqueradeToTry(masquerades, tt.triedMasquerades)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/fronted_test.go
+++ b/fronted_test.go
@@ -132,7 +132,7 @@ func TestVet(t *testing.T) {
 	t.Fatal("None of the default masquerades vetted successfully")
 }
 
-func TestLoadCandidates(t *testing.T) {
+func TestLoadMasquerades(t *testing.T) {
 	providers := testProviders()
 
 	expected := make(map[Masquerade]bool)
@@ -142,11 +142,11 @@ func TestLoadCandidates(t *testing.T) {
 		}
 	}
 
-	d := &fronted{
-		masquerades: make(sortedMasquerades, 0, len(expected)),
-	}
+	newMasquerades := loadMasquerades(providers, len(expected))
 
-	d.loadCandidates(providers)
+	d := &fronted{
+		masquerades: newMasquerades,
+	}
 
 	actual := make(map[Masquerade]bool)
 	count := 0


### PR DESCRIPTION
As we're iterating through and dialing masquerades, the best masquerade to dial has quite likely changed. This means we should re-sort the masquerades to make sure we're always dialing the best one.