### PR TITLE
Fix race condition

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -42,7 +42,7 @@ func (f *fronted) prepopulateFronts(cacheFile string) {
 	now := time.Now()
 
 	// update last succeeded status of masquerades based on cached values
-	for _, fr := range f.fronts {
+	for _, fr := range f.fronts.fronts {
 		for _, cf := range cachedFronts {
 			sameFront := cf.ProviderID == fr.getProviderID() && cf.Domain == fr.getDomain() && cf.IpAddress == fr.getIpAddress()
 			cachedValueFresh := now.Sub(fr.lastSucceeded()) < f.maxAllowedCachedAge
@@ -81,10 +81,7 @@ func (f *fronted) maintainCache(cacheFile string) {
 func (f *fronted) updateCache(cacheFile string) {
 	log.Debugf("Updating cache at %v", cacheFile)
 	cache := f.fronts.sortedCopy()
-	sizeToSave := len(cache)
-	if f.maxCacheSize < sizeToSave {
-		sizeToSave = f.maxCacheSize
-	}
+	sizeToSave := min(f.maxCacheSize, len(cache))
 	b, err := json.Marshal(cache[:sizeToSave])
 	if err != nil {
 		log.Errorf("Unable to marshal cache to JSON: %v", err)

--- a/cache_test.go
+++ b/cache_test.go
@@ -29,7 +29,7 @@ func TestCaching(t *testing.T) {
 	log.Debug("Creating fronted")
 	makeFronted := func() *fronted {
 		f := &fronted{
-			fronts:              make(sortedFronts, 0, 1000),
+			fronts:              newSortedFronts(0),
 			maxAllowedCachedAge: 250 * time.Millisecond,
 			maxCacheSize:        4,
 			cacheSaveInterval:   50 * time.Millisecond,
@@ -51,7 +51,7 @@ func TestCaching(t *testing.T) {
 	f := makeFronted()
 
 	log.Debug("Adding fronts")
-	f.fronts = append(f.fronts, mb, mc, md)
+	f.fronts.fronts = append(f.fronts.fronts, mb, mc, md)
 
 	readCached := func() []*front {
 		log.Debug("Reading cached fronts")

--- a/front.go
+++ b/front.go
@@ -363,6 +363,8 @@ func NewStatusCodeValidator(reject []int) ResponseValidator {
 // slice of masquerade sorted by last vetted time
 type sortedFronts []Front
 
+var frontsMu sync.RWMutex
+
 func (m sortedFronts) Len() int      { return len(m) }
 func (m sortedFronts) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
 func (m sortedFronts) Less(i, j int) bool {
@@ -377,9 +379,30 @@ func (m sortedFronts) Less(i, j int) bool {
 
 func (m sortedFronts) sortedCopy() sortedFronts {
 	c := make(sortedFronts, len(m))
+	frontsMu.Lock()
+	defer frontsMu.Unlock()
 	copy(c, m)
 	sort.Sort(c)
 	return c
+}
+
+func (m sortedFronts) addFronts(fronts sortedFronts) {
+	// Add new masquerades to the existing masquerades slice, but add them at the beginning.
+	frontsMu.Lock()
+	defer frontsMu.Unlock()
+	m = append(m, fronts...)
+}
+
+func (m sortedFronts) size() int {
+	frontsMu.Lock()
+	defer frontsMu.Unlock()
+	return len(m)
+}
+
+func (m sortedFronts) frontAt(i int) Front {
+	frontsMu.Lock()
+	defer frontsMu.Unlock()
+	return m[i]
 }
 
 func (fr *front) markCacheDirty() {

--- a/front.go
+++ b/front.go
@@ -377,32 +377,32 @@ func (m sortedFronts) Less(i, j int) bool {
 	}
 }
 
-func (m sortedFronts) sortedCopy() sortedFronts {
-	c := make(sortedFronts, len(m))
+func (m *sortedFronts) sortedCopy() sortedFronts {
+	c := make(sortedFronts, len(*m))
 	frontsMu.Lock()
 	defer frontsMu.Unlock()
-	copy(c, m)
+	copy(c, *m)
 	sort.Sort(c)
 	return c
 }
 
-func (m sortedFronts) addFronts(fronts sortedFronts) {
+func (m *sortedFronts) addFronts(fronts sortedFronts) {
 	// Add new masquerades to the existing masquerades slice, but add them at the beginning.
 	frontsMu.Lock()
 	defer frontsMu.Unlock()
-	m = append(m, fronts...)
+	*m = append(fronts, *m...)
 }
 
-func (m sortedFronts) size() int {
+func (m *sortedFronts) size() int {
 	frontsMu.Lock()
 	defer frontsMu.Unlock()
-	return len(m)
+	return len(*m)
 }
 
-func (m sortedFronts) frontAt(i int) Front {
+func (m *sortedFronts) frontAt(i int) Front {
 	frontsMu.Lock()
 	defer frontsMu.Unlock()
-	return m[i]
+	return (*m)[i]
 }
 
 func (fr *front) markCacheDirty() {

--- a/front.go
+++ b/front.go
@@ -377,32 +377,32 @@ func (m sortedFronts) Less(i, j int) bool {
 	}
 }
 
-func (m *sortedFronts) sortedCopy() sortedFronts {
-	c := make(sortedFronts, len(*m))
-	frontsMu.Lock()
-	defer frontsMu.Unlock()
-	copy(c, *m)
-	sort.Sort(c)
+func (m *sortedFronts) sortedCopy() []Front {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c := make([]Front, len(m.fronts))
+	copy(c, m.fronts)
+	sort.Sort(sortedFronts{fronts: c})
 	return c
 }
 
-func (m *sortedFronts) addFronts(fronts sortedFronts) {
+func (m *sortedFronts) addFronts(fronts []Front) {
 	// Add new masquerades to the existing masquerades slice, but add them at the beginning.
-	frontsMu.Lock()
-	defer frontsMu.Unlock()
-	*m = append(fronts, *m...)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.fronts = append(fronts, m.fronts...)
 }
 
 func (m *sortedFronts) size() int {
-	frontsMu.Lock()
-	defer frontsMu.Unlock()
-	return len(*m)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.fronts)
 }
 
 func (m *sortedFronts) frontAt(i int) Front {
-	frontsMu.Lock()
-	defer frontsMu.Unlock()
-	return (*m)[i]
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.fronts[i]
 }
 
 func (fr *front) markCacheDirty() {

--- a/fronted_test.go
+++ b/fronted_test.go
@@ -155,7 +155,7 @@ func doTestDomainFronting(t *testing.T, cacheFile string, expectedMasqueradesAtE
 	// Check the number of masquerades at the end, waiting until we get the right number
 	masqueradesAtEnd := 0
 	for i := 0; i < 1000; i++ {
-		masqueradesAtEnd = len(d.fronts)
+		masqueradesAtEnd = len(d.fronts.fronts)
 		if masqueradesAtEnd == expectedMasqueradesAtEnd {
 			break
 		}
@@ -761,9 +761,9 @@ func TestFindWorkingMasquerades(t *testing.T) {
 			}
 			f.providers = make(map[string]*Provider)
 			f.providers["testProviderId"] = NewProvider(nil, "", nil, nil, nil, nil, "")
-			f.fronts = make(sortedFronts, len(tt.masquerades))
-			for i, m := range tt.masquerades {
-				f.fronts[i] = m
+			f.fronts = newSortedFronts(0)
+			for _, m := range tt.masquerades {
+				f.fronts.fronts = append(f.fronts.fronts, m)
 			}
 
 			f.tryAllFronts()
@@ -806,9 +806,9 @@ func TestLoadFronts(t *testing.T) {
 	cacheDirty := make(chan interface{}, 10)
 	masquerades := loadFronts(providers, cacheDirty)
 
-	assert.Equal(t, 4, len(masquerades), "Unexpected number of masquerades loaded")
+	assert.Equal(t, 4, len(masquerades.fronts), "Unexpected number of masquerades loaded")
 
-	for _, m := range masquerades {
+	for _, m := range masquerades.fronts {
 		assert.True(t, expected[m.getDomain()], "Unexpected masquerade domain: %s", m.getDomain())
 	}
 }


### PR DESCRIPTION
This popped up in flashlight tests as a race condition:

```
WARNING: DATA RACE
Read at 0x00c000695d00 by goroutine 35:
  runtime.slicecopy()
      /opt/hostedtoolcache/go/1.22.4/x64/src/runtime/slice.go:325 +0x0
  github.com/getlantern/fronted.sortedFronts.sortedCopy()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/front.go:380 +0x16b
  github.com/getlantern/fronted.(*fronted).updateCache()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/cache.go:83 +0xfd
  github.com/getlantern/fronted.(*fronted).maintainCache()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/cache.go:75 +0x5e
  github.com/getlantern/fronted.(*fronted).initCaching.gowrap1()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/cache.go:12 +0x4f

Previous write at 0x00c000695d00 by goroutine 68:
  runtime.slicecopy()
      /opt/hostedtoolcache/go/1.22.4/x64/src/runtime/slice.go:325 +0x0
  github.com/getlantern/fronted.(*fronted).addFronts()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/fronted.go:623 +0x17d
  github.com/getlantern/fronted.(*fronted).onNewFronts()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/fronted.go:263 +0x144
  github.com/getlantern/fronted.(*fronted).onNewFrontsConfig()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/fronted.go:248 +0x124
  github.com/getlantern/fronted.(*fronted).keepCurrent.func1()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/fronted.go:216 +0x13c
```