### PR TITLE
Use copy of fronts to avoid race condition

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -42,7 +42,7 @@ func (f *fronted) prepopulateFronts(cacheFile string) {
 	now := time.Now()
 
 	// update last succeeded status of masquerades based on cached values
-	for _, fr := range f.fronts {
+	for _, fr := range f.fronts.fronts {
 		for _, cf := range cachedFronts {
 			sameFront := cf.ProviderID == fr.getProviderID() && cf.Domain == fr.getDomain() && cf.IpAddress == fr.getIpAddress()
 			cachedValueFresh := now.Sub(fr.lastSucceeded()) < f.maxAllowedCachedAge

--- a/cache_test.go
+++ b/cache_test.go
@@ -29,7 +29,7 @@ func TestCaching(t *testing.T) {
 	log.Debug("Creating fronted")
 	makeFronted := func() *fronted {
 		f := &fronted{
-			fronts:              make(sortedFronts, 0, 1000),
+			fronts:              newThreadSafeFronts(1000),
 			maxAllowedCachedAge: 250 * time.Millisecond,
 			maxCacheSize:        4,
 			cacheSaveInterval:   50 * time.Millisecond,
@@ -51,7 +51,7 @@ func TestCaching(t *testing.T) {
 	f := makeFronted()
 
 	log.Debug("Adding fronts")
-	f.fronts = append(f.fronts, mb, mc, md)
+	f.fronts.fronts = append(f.fronts.fronts, mb, mc, md)
 
 	readCached := func() []*front {
 		log.Debug("Reading cached fronts")

--- a/fronted.go
+++ b/fronted.go
@@ -320,7 +320,7 @@ func (f *fronted) tryAllFronts() {
 	pool := pond.NewPool(40)
 
 	// Submit all fronts to the worker pool.
-	for i := range f.fronts.frontSize() {
+	for i := 0; i < f.fronts.frontSize(); i++ {
 		m := f.fronts.frontAt(i)
 		pool.Submit(func() {
 			if f.isStopped() {

--- a/fronted.go
+++ b/fronted.go
@@ -581,7 +581,7 @@ func loadFronts(providers map[string]*Provider, cacheDirty chan interface{}) []F
 		// make a shuffled copy of arr
 		// ('inside-out' Fisher-Yates)
 		sh := make([]*Masquerade, size)
-		for i := range size {
+		for i := 0; i < size; i++ {
 			j := rand.IntN(i + 1) // 0 <= j <= i
 			sh[i] = sh[j]
 			sh[j] = arr[i]

--- a/fronted_test.go
+++ b/fronted_test.go
@@ -155,7 +155,7 @@ func doTestDomainFronting(t *testing.T, cacheFile string, expectedMasqueradesAtE
 	// Check the number of masquerades at the end, waiting until we get the right number
 	masqueradesAtEnd := 0
 	for i := 0; i < 1000; i++ {
-		masqueradesAtEnd = len(d.fronts)
+		masqueradesAtEnd = len(d.fronts.fronts)
 		if masqueradesAtEnd == expectedMasqueradesAtEnd {
 			break
 		}
@@ -761,9 +761,10 @@ func TestFindWorkingMasquerades(t *testing.T) {
 			}
 			f.providers = make(map[string]*Provider)
 			f.providers["testProviderId"] = NewProvider(nil, "", nil, nil, nil, nil, "")
-			f.fronts = make(sortedFronts, len(tt.masquerades))
+			//f.fronts = make(sortedFronts, len(tt.masquerades))
+			f.fronts = newThreadSafeFronts(len(tt.masquerades))
 			for i, m := range tt.masquerades {
-				f.fronts[i] = m
+				f.fronts.fronts[i] = m
 			}
 
 			f.tryAllFronts()


### PR DESCRIPTION
This fixes this race condition:

```
WARNING: DATA RACE
Read at 0x00c000695d00 by goroutine 35:
  runtime.slicecopy()
      /opt/hostedtoolcache/go/1.22.4/x64/src/runtime/slice.go:325 +0x0
  github.com/getlantern/fronted.sortedFronts.sortedCopy()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/front.go:380 +0x16b
  github.com/getlantern/fronted.(*fronted).updateCache()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/cache.go:83 +0xfd
  github.com/getlantern/fronted.(*fronted).maintainCache()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/cache.go:75 +0x5e
  github.com/getlantern/fronted.(*fronted).initCaching.gowrap1()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/cache.go:12 +0x4f

Previous write at 0x00c000695d00 by goroutine 68:
  runtime.slicecopy()
      /opt/hostedtoolcache/go/1.22.4/x64/src/runtime/slice.go:325 +0x0
  github.com/getlantern/fronted.(*fronted).addFronts()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/fronted.go:623 +0x17d
  github.com/getlantern/fronted.(*fronted).onNewFronts()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/fronted.go:263 +0x144
  github.com/getlantern/fronted.(*fronted).onNewFrontsConfig()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/fronted.go:248 +0x124
  github.com/getlantern/fronted.(*fronted).keepCurrent.func1()
      /home/runner/go/pkg/mod/github.com/getlantern/fronted@v0.0.0-20250330001402-75899df1c2cd/fronted.go:216 +0x13c
```

This pull request introduces thread-safe handling of `fronts` in the `fronted` package by replacing the `sortedFronts` type with a new `threadSafeFronts` struct. This change ensures that concurrent access to the `fronts` is properly synchronized, improving the safety and reliability of the code. The most important changes include the addition of the `threadSafeFronts` struct, updates to the `fronted` struct, and modifications to various functions to use the new thread-safe methods.

Thread-safe handling of `fronts`:

* [`front.go`](diffhunk://#diff-b1087a862b8479e16f1d16840ee34f01726ed01d0d96bec557d1c929d8be0d90R363-R401): Introduced the `threadSafeFronts` struct with methods for safely accessing and modifying the `fronts` slice.

Updates to the `fronted` struct:

* [`fronted.go`](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L52-R52): Changed the `fronts` field in the `fronted` struct to use `*threadSafeFronts` instead of `sortedFronts`.

Modifications to functions:

* [`fronted.go`](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L263-R263): Updated functions such as `onNewFronts`, `tryAllFronts`, and `hasEnoughWorkingFronts` to use the new thread-safe methods for accessing `fronts`. [[1]](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L263-R263) [[2]](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L323-R324) [[3]](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L351-L362)
* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042L45-R45): Adjusted the `prepopulateFronts` function to iterate over `f.fronts.fronts` instead of `f.fronts`.
* `fronted_test.go` and `cache_test.go`: Modified test cases to accommodate the changes in the `fronted` struct and the use of `threadSafeFronts`. [[1]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L32-R32) [[2]](diffhunk://#diff-7e0c97f6787834f9632ea5a23fe088bdd6d6fd5a131b79ef145b1533df09eeb1L54-R54) [[3]](diffhunk://#diff-0a41ec4648a957695e9c3fef0c4c247d2fc839a92265fe9391a29ca7399dbc9fL158-R158) [[4]](diffhunk://#diff-0a41ec4648a957695e9c3fef0c4c247d2fc839a92265fe9391a29ca7399dbc9fL764-R767)This pull request includes several changes to the `fronted.go` file to improve concurrency and correctness. The most important changes include modifying loops to use the correct range syntax, switching mutex locks to read locks where appropriate, and updating the method for appending sorted fronts.

Concurrency improvements:

* [`fronted.go`](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L352-R359): Changed `frontSize` and `frontAt` methods to use read locks (`RLock`) instead of regular locks to allow concurrent read access.

Correctness improvements:

* [`fronted.go`](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L323-R323): Modified loops in `tryAllFronts` and `loadFronts` functions to use the correct range syntax (`for i := range ...`) for improved readability and correctness. [[1]](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L323-R323) [[2]](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L596-R596)
* [`fronted.go`](diffhunk://#diff-4c0bae8138ac14baaa1ae94e99e7cd771ca5a489668864545f5e95e2707c4491L623-R623): Updated the `addFronts` method to append sorted fronts correctly by using `sortedCopy()`.