### PR TITLE
Add WithDialer option for custom TCP dialer injection

### DIFF
--- a/front.go
+++ b/front.go
@@ -88,10 +88,10 @@ type front struct {
 	ProviderID string
 	mx         sync.RWMutex
 	cacheDirty chan interface{}
-	dialFunc   func(ctx context.Context, network, addr string) (net.Conn, error)
+	dialFunc   DialFunc
 }
 
-func newFront(m *Masquerade, providerID string, cacheDirty chan interface{}, dialFunc func(ctx context.Context, network, addr string) (net.Conn, error)) Front {
+func newFront(m *Masquerade, providerID string, cacheDirty chan interface{}, dialFunc DialFunc) Front {
 	return &front{
 		Masquerade:    *m,
 		ProviderID:    providerID,

--- a/fronted_test.go
+++ b/fronted_test.go
@@ -799,7 +799,7 @@ func TestLoadFronts(t *testing.T) {
 
 	// Create the cache dirty channel
 	cacheDirty := make(chan interface{}, 10)
-	masquerades := loadFronts(providers, cacheDirty)
+	masquerades := loadFronts(providers, cacheDirty, nil)
 
 	assert.Equal(t, 4, len(masquerades), "Unexpected number of masquerades loaded")
 


### PR DESCRIPTION
## Summary
- Adds a `WithDialer(func(ctx context.Context, network, addr string) (net.Conn, error))` option to `fronted`
- Threads the custom dialer through `loadFronts` → `newFront` → `front.dial()`, adapting it to `tlsdialer.Dialer.DoDial` via `context.WithTimeout`
- Falls back to `(&net.Dialer{}).DialContext` when no custom dialer is provided (preserving existing behavior)

## Test plan
- [ ] `go build ./...` compiles cleanly
- [ ] `go vet ./...` passes
- [ ] Existing tests pass (`go test ./...`)
- [ ] Verify domain fronting still works end-to-end with default dialer
- [ ] Verify custom dialer is called when injected via `WithDialer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)